### PR TITLE
feat/direct instantiation constexpr for

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: Google

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: Google

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "constexpr_for",
+    name = "cex_for_loop",
 )
 
 bazel_dep(name = "googletest", version = "1.14.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "8709ca640b603aac932b309e5c6d752f13f450b8766d9c602ee0ebbaf103951a",
+  "moduleFileHash": "fd89435e0ff0cf8e014e244c493f888494303e2559944ed3204a1cd6855a11be",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -17,10 +17,10 @@
   },
   "moduleDepGraph": {
     "<root>": {
-      "name": "constexpr_for",
+      "name": "cex_for_loop",
       "version": "",
       "key": "<root>",
-      "repoName": "constexpr_for",
+      "repoName": "cex_for_loop",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [],
       "extensionUsages": [],

--- a/include/BUILD
+++ b/include/BUILD
@@ -2,7 +2,8 @@ cc_library(
     name = "CEXForLoop",
     srcs = glob(["impl/*.h"]),
     hdrs = [
-        "cex_for_loop.h"
+        "cex_for_loop.h",
+        "bool_expression_functors.h",
     ],
     visibility = ["//visibility:public"],
     deps = [],

--- a/include/BUILD
+++ b/include/BUILD
@@ -1,0 +1,9 @@
+cc_library(
+    name = "CEXForLoop",
+    srcs = glob(["impl/*.h"]),
+    hdrs = [
+        "cex_for_loop.h"
+    ],
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/include/bool_expression_functors.h
+++ b/include/bool_expression_functors.h
@@ -1,0 +1,44 @@
+#ifndef BOOL_EXPRESSION_FUNCTORS_H
+#define BOOL_EXPRESSION_FUNCTORS_H
+
+namespace CEXForLoop {
+
+struct BoolExpressionFunctor_EQ {
+  inline static constexpr bool func(long long lhs, long long rhs) {
+    return lhs == rhs;
+  }
+};
+
+struct BoolExpressionFunctor_NEQ {
+  inline static constexpr bool func(long long lhs, long long rhs) {
+    return lhs != rhs;
+  }
+};
+
+struct BoolExpressionFunctor_LT {
+  inline static constexpr bool func(long long lhs, long long rhs) {
+    return lhs < rhs;
+  }
+};
+
+struct BoolExpressionFunctor_LEQ {
+  inline static constexpr bool func(long long lhs, long long rhs) {
+    return lhs <= rhs;
+  }
+};
+
+struct BoolExpressionFunctor_GT {
+  inline static constexpr bool func(long long lhs, long long rhs) {
+    return lhs > rhs;
+  }
+};
+
+struct BoolExpressionFunctor_GEQ {
+  inline static constexpr bool func(long long lhs, long long rhs) {
+    return lhs >= rhs;
+  }
+};
+
+}  // namespace CEXForLoop
+
+#endif  // BOOL_EXPRESSION_FUNCTORS_H

--- a/include/cex_for_loop.h
+++ b/include/cex_for_loop.h
@@ -1,0 +1,20 @@
+#ifndef CEX_FOR_LOOP_H
+#define CEX_FOR_LOOP_H
+
+#include <cstddef>
+#include <type_traits>
+
+#include "impl/cex_for_loop.h"
+
+namespace CEXForLoop {
+
+template <long long start, long long end, long long inc, typename Functor>
+constexpr typename Functor::Data constexpr_for(
+    typename Functor::Data initial_values) {
+  return impl::Thing<Functor>::template constexpr_for<start, end, inc>(
+      initial_values);
+};
+
+}  // namespace CEXForLoop
+
+#endif  // CEX_FOR_LOOP_H

--- a/include/cex_for_loop.h
+++ b/include/cex_for_loop.h
@@ -1,18 +1,16 @@
 #ifndef CEX_FOR_LOOP_H
 #define CEX_FOR_LOOP_H
 
-#include <cstddef>
-#include <type_traits>
-
 #include "impl/cex_for_loop.h"
 
 namespace CEXForLoop {
 
-template <long long start, long long end, long long inc, typename Functor>
-constexpr typename Functor::Data constexpr_for(
-    typename Functor::Data initial_values) {
-  return impl::Thing<Functor>::template constexpr_for<start, end, inc>(
-      initial_values);
+template <long long start, long long end, long long inc,
+          typename BoolExpressionFunctor, typename BodyFunctor>
+constexpr typename BodyFunctor::Data constexpr_for(
+    typename BodyFunctor::Data initial_values) {
+  return impl::ConstexprFor<BoolExpressionFunctor, BodyFunctor>::template func<
+      start, end, inc>(initial_values);
 };
 
 }  // namespace CEXForLoop

--- a/include/impl/cex_for_loop.h
+++ b/include/impl/cex_for_loop.h
@@ -1,26 +1,27 @@
 #ifndef IMPL_CEX_FOR_LOOP_H
 #define IMPL_CEX_FOR_LOOP_H
 
-#include <cstddef>
 #include <type_traits>
 
 namespace CEXForLoop {
 namespace impl {
 
-template <typename Functor>
-struct Thing {
-  using FunctorData = typename Functor::Data;
+template <typename BoolExpressionFunctor, typename BodyFunctor>
+struct ConstexprFor {
+  using FunctorData = typename BodyFunctor::Data;
 
   template <long long start, long long end, long long inc>
-  static constexpr auto constexpr_for(FunctorData initial_data) ->
-      typename std::enable_if<(start != end), FunctorData>::type {
-    return constexpr_for<start + inc, end, inc>(
-        Functor::template func<start>(initial_data));
+  static constexpr auto func(FunctorData initial_data) ->
+      typename std::enable_if<BoolExpressionFunctor::func(start, end),
+                              FunctorData>::type {
+    return func<start + inc, end, inc>(
+        BodyFunctor::template func<start>(initial_data));
   };
 
   template <long long start, long long end, long long inc>
-  static constexpr auto constexpr_for(FunctorData initial_data) ->
-      typename std::enable_if<(start == end), FunctorData>::type {
+  static constexpr auto func(FunctorData initial_data) ->
+      typename std::enable_if<!BoolExpressionFunctor::func(start, end),
+                              FunctorData>::type {
     return initial_data;
   };
 };

--- a/include/impl/cex_for_loop.h
+++ b/include/impl/cex_for_loop.h
@@ -1,0 +1,31 @@
+#ifndef IMPL_CEX_FOR_LOOP_H
+#define IMPL_CEX_FOR_LOOP_H
+
+#include <cstddef>
+#include <type_traits>
+
+namespace CEXForLoop {
+namespace impl {
+
+template <typename Functor>
+struct Thing {
+  using FunctorData = typename Functor::Data;
+
+  template <long long start, long long end, long long inc>
+  static constexpr auto constexpr_for(FunctorData initial_data) ->
+      typename std::enable_if<(start != end), FunctorData>::type {
+    return constexpr_for<start + inc, end, inc>(
+        Functor::template func<start>(initial_data));
+  };
+
+  template <long long start, long long end, long long inc>
+  static constexpr auto constexpr_for(FunctorData initial_data) ->
+      typename std::enable_if<(start == end), FunctorData>::type {
+    return initial_data;
+  };
+};
+
+}  // namespace impl
+}  // namespace CEXForLoop
+
+#endif  // IMPL_CEX_FOR_LOOP_H

--- a/test/BUILD
+++ b/test/BUILD
@@ -5,6 +5,7 @@ cc_test(
         "constexpr_for_test.cc",
     ],
     deps = [
+        "//include:CEXForLoop",
         "@googletest//:gtest_main",
     ],
 )

--- a/test/constexpr_for_test.cc
+++ b/test/constexpr_for_test.cc
@@ -1,32 +1,34 @@
-#include <array>
 #include <gtest/gtest.h>
+
+#include <array>
 
 #include "include/cex_for_loop.h"
 
 struct TestFunctor {
   // typedef std::tuple<int, char> FunctorData;
   struct Data {
-    std::array<int, 10> i_tracker;
+    std::array<int, 5> i_tracker;
     int foo;
   };
 
-  template <std::size_t i>
+  template <long long i>
   static constexpr Data func(Data input_data) {
+    std::get<i>(input_data.i_tracker) += i;
     input_data.foo = i;
-    std::get<i>(input_data.i_tracker) = i;
     return input_data;
   };
 };
 
-TEST(ConstexprFor, basic_iteration) {
-  constexpr TestFunctor::Data test_initial_values = {0, 0};
+TEST(ConstexprFor, ZeroToNMinusOne) {
+  constexpr TestFunctor::Data test_initial_values = {{0, 0, 0, 0, 0}, 0};
 
   constexpr auto result =
-      CEXForLoop::constexpr_for<0, 5, 1, TestFunctor>(test_initial_values);
+      CEXForLoop::constexpr_for<0, test_initial_values.i_tracker.size(), 1,
+                                TestFunctor>(test_initial_values);
 
+  constexpr std::array<int, 5> expected_i_tracker{0, 1, 2, 3, 4};
+  for(int i = 0; i < expected_i_tracker.size(); i++){
+    ASSERT_EQ(result.i_tracker[i], expected_i_tracker[i]);
+  }
   ASSERT_EQ(result.foo, 4);
-  ASSERT_EQ(std::get<0>(result.i_tracker), 0);
-  ASSERT_EQ(std::get<1>(result.i_tracker), 1);
-  ASSERT_EQ(std::get<2>(result.i_tracker), 2);
-  ASSERT_EQ(std::get<3>(result.i_tracker), 3);
 }

--- a/test/constexpr_for_test.cc
+++ b/test/constexpr_for_test.cc
@@ -2,33 +2,64 @@
 
 #include <array>
 
+#include "include/bool_expression_functors.h"
 #include "include/cex_for_loop.h"
 
-struct TestFunctor {
-  // typedef std::tuple<int, char> FunctorData;
+struct TestFunctorAdd {
   struct Data {
     std::array<int, 5> i_tracker;
-    int foo;
+    int last_i_value;
   };
 
   template <long long i>
   static constexpr Data func(Data input_data) {
     std::get<i>(input_data.i_tracker) += i;
-    input_data.foo = i;
+    input_data.last_i_value = i;
+    return input_data;
+  };
+};
+
+struct TestFunctorSet {
+  struct Data {
+    std::array<int, 5> i_tracker;
+    int last_i_value;
+  };
+
+  template <long long i>
+  static constexpr Data func(Data input_data) {
+    std::get<i>(input_data.i_tracker) = i;
+    input_data.last_i_value = i;
     return input_data;
   };
 };
 
 TEST(ConstexprFor, ZeroToNMinusOne) {
-  constexpr TestFunctor::Data test_initial_values = {{0, 0, 0, 0, 0}, 0};
+  constexpr TestFunctorAdd::Data test_initial_values = {{0, 0, 0, 0, 0}, 0};
 
   constexpr auto result =
       CEXForLoop::constexpr_for<0, test_initial_values.i_tracker.size(), 1,
-                                TestFunctor>(test_initial_values);
+                                CEXForLoop::BoolExpressionFunctor_LT,
+                                TestFunctorAdd>(test_initial_values);
 
   constexpr std::array<int, 5> expected_i_tracker{0, 1, 2, 3, 4};
-  for(int i = 0; i < expected_i_tracker.size(); i++){
+  for (std::size_t i = 0; i < expected_i_tracker.size(); i++) {
     ASSERT_EQ(result.i_tracker[i], expected_i_tracker[i]);
   }
-  ASSERT_EQ(result.foo, 4);
+  ASSERT_EQ(result.last_i_value, 4);
+}
+
+TEST(ConstexprFor, NMinusOneToZero) {
+  constexpr TestFunctorSet::Data test_initial_values = {
+      {0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, 0};
+
+  constexpr auto result =
+      CEXForLoop::constexpr_for<test_initial_values.i_tracker.size() - 1, 0, -1,
+                                CEXForLoop::BoolExpressionFunctor_GEQ,
+                                TestFunctorSet>(test_initial_values);
+
+  constexpr std::array<int, 5> expected_i_tracker{0, 1, 2, 3, 4};
+  for (std::size_t i = 0; i < expected_i_tracker.size(); i++) {
+    ASSERT_EQ(result.i_tracker[i], expected_i_tracker[i]);
+  }
+  ASSERT_EQ(result.last_i_value, 0);
 }

--- a/test/constexpr_for_test.cc
+++ b/test/constexpr_for_test.cc
@@ -1,5 +1,32 @@
+#include <array>
 #include <gtest/gtest.h>
 
-TEST(EXAMPLE, ting) {
+#include "include/cex_for_loop.h"
 
+struct TestFunctor {
+  // typedef std::tuple<int, char> FunctorData;
+  struct Data {
+    std::array<int, 10> i_tracker;
+    int foo;
+  };
+
+  template <std::size_t i>
+  static constexpr Data func(Data input_data) {
+    input_data.foo = i;
+    std::get<i>(input_data.i_tracker) = i;
+    return input_data;
+  };
+};
+
+TEST(ConstexprFor, basic_iteration) {
+  constexpr TestFunctor::Data test_initial_values = {0, 0};
+
+  constexpr auto result =
+      CEXForLoop::constexpr_for<0, 5, 1, TestFunctor>(test_initial_values);
+
+  ASSERT_EQ(result.foo, 4);
+  ASSERT_EQ(std::get<0>(result.i_tracker), 0);
+  ASSERT_EQ(std::get<1>(result.i_tracker), 1);
+  ASSERT_EQ(std::get<2>(result.i_tracker), 2);
+  ASSERT_EQ(std::get<3>(result.i_tracker), 3);
 }


### PR DESCRIPTION
# About

This pr merges linear/direct constexpr for loop implementation with main.

- **feat: implement 0 to N-1 constexpr for loop**
- **chore: add clang-tidy clang-format dot files**
- **chore: add MODULE.bazel.lock**
- **test: refactor 0 to N-1 test**
- **feat: pass bool expression functor enabling generic for loop**
