### PR TITLE
refactor/update and apply clang tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,101 @@
 ---
-BasedOnStyle: Google
+# Configure clang-tidy for this project.
+
+# Here is an explanation for why some of the checks are disabled:
+#
+#
+#  -bugprone-easily-swappable-parameters: too many false positives.
+#
+#  -bugprone-unchecked-optional-access: too many false positives in tests.
+#     Despite what the documentation says, this warning appears after
+#     `ASSERT_TRUE(variable)` or `ASSERT_TRUE(variable.has_value())`.
+#
+#  -misc-non-private-member-variables-in-classes: getters and setters are stupid
+#      and don't solve the root issue. Bad design is bad design--this check
+#      won't solve that.
+#
+#  -modernize-use-trailing-return-type: clang-tidy recommends using
+#      `auto Foo() -> std::string { return ...; }`, we think the code is less
+#      readable in this form.
+#
+#  --modernize-concat-nested-namespaces: clang-tidy recommends
+#      `namespace google::cloud {}` over `namespace google { namespace cloud { } }`
+#      We need to support C++14, which does not supported nested namespaces.
+#
+#  --modernize-use-nodiscard: clang-tidy recommends adding a nodiscard annotation
+#      to functions where the return value should not be ignored.
+#      We need to support C++14, which does not supported the annotation.
+#
+#  -modernize-return-braced-init-list: We think removing typenames and using
+#      only braced-init can hurt readability.
+#
+#  -modernize-avoid-c-arrays: We only use C arrays when they seem to be the
+#      right tool for the job, such as `char foo[] = "hello"`. In these cases,
+#      avoiding C arrays often makes the code less readable, and std::array is
+#      not a drop-in replacement because it doesn't deduce the size.
+#
+#  -performance-move-const-arg: This warning requires the developer to
+#      know/care more about the implementation details of types/functions than
+#      should be necessary. For example, `A a; F(std::move(a));` will trigger a
+#      warning IFF `A` is a trivial type (and therefore the move is
+#      meaningless). It would also warn if `F` accepts by `const&`, which is
+#      another detail that the caller need not care about.
+#
+#  -performance-avoid-endl: we would like to turn this on, but there are too
+#      many legitimate uses in our samples.
+#
+#  -readability-magic-numbers: this is a good principle, but there are times
+#      (like test fixtures) when a magic number makes sense and this check is
+#      annoying
+#
+Checks: >
+  -*,
+  abseil-*,
+  bugprone-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-unchecked-optional-access,
+  -misc-non-private-member-variables-in-classes,
+  -modernize-return-braced-init-list,
+  -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-nodiscard,
+  -modernize-avoid-c-arrays,
+  -performance-move-const-arg,
+  -performance-avoid-endl,
+  -readability-magic-numbers,
+
+# Turn all the warnings from the checks above into errors.
+WarningsAsErrors: "*"
+
+HeaderFilterRegex: "include.*\\.h$"
+
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,           value: aNy_CasE  }
+  - { key: readability-identifier-naming.VariableCase,           value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberSuffix,      value: _          }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
+  - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantPrefix,       value: k         }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
+  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
+  - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1   }
+  - { key: readability-function-cognitive-complexity.IgnoreMacros,  value: 1   }

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ collaboration processes in terms of writing code and project direction.
 
 ### Standards
 
-Some standards/best practices that are adhered to on a best-effort basis.
+This project follows these standards:
 
-- [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
-  - `clang-format` formatting (config file tracked)
 - [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-  - `clang-tidy` linting (config file tracked)
+- [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
+  - `clang-format` formatting (see `.clang-format` for config details)
+  - `clang-tidy` linting (see `.clang-tidy` for config details)
 
 ### Setup the Test Environment
 

--- a/include/bool_expression_functors.h
+++ b/include/bool_expression_functors.h
@@ -1,44 +1,50 @@
 #ifndef BOOL_EXPRESSION_FUNCTORS_H
 #define BOOL_EXPRESSION_FUNCTORS_H
 
-namespace CEXForLoop {
+namespace cex_for_loop {
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_EQ {
   inline static constexpr bool func(long long lhs, long long rhs) {
     return lhs == rhs;
   }
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_NEQ {
   inline static constexpr bool func(long long lhs, long long rhs) {
     return lhs != rhs;
   }
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_LT {
   inline static constexpr bool func(long long lhs, long long rhs) {
     return lhs < rhs;
   }
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_LEQ {
   inline static constexpr bool func(long long lhs, long long rhs) {
     return lhs <= rhs;
   }
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_GT {
   inline static constexpr bool func(long long lhs, long long rhs) {
     return lhs > rhs;
   }
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_GEQ {
   inline static constexpr bool func(long long lhs, long long rhs) {
     return lhs >= rhs;
   }
 };
 
-}  // namespace CEXForLoop
+}  // namespace cex_for_loop
 
 #endif  // BOOL_EXPRESSION_FUNCTORS_H

--- a/include/cex_for_loop.h
+++ b/include/cex_for_loop.h
@@ -5,12 +5,21 @@
 
 namespace cex_for_loop {
 
-template <long long Start, long long End, long long Inc,
+template <typename IType, IType Start, IType End, IType Inc,
           typename BoolExpressionFunctor, typename BodyFunctor>
 constexpr typename BodyFunctor::Data constexpr_for(
     typename BodyFunctor::Data initial_values) {
-  return impl::ExponentialCEXForFunctor<BoolExpressionFunctor, BodyFunctor,
-                                        Start, End, Inc,
+  static_assert(!static_cast<bool>(std::is_const<IType>().value),
+                "User provided type may NOT be const qualified.");
+  static_assert(!static_cast<bool>(std::is_volatile<IType>().value),
+                "User provided type may NOT be volatile qualified.");
+  static_assert(
+      std::is_integral<IType>().value && not std::is_same<IType, bool>(),
+      "User provided type must be an integer type (no bools allowed).");
+  static_assert(std::is_signed<IType>().value,
+                "User provided type must be signed integer.");
+  return impl::ExponentialCEXForFunctor<IType, Start, End, Inc,
+                                        BoolExpressionFunctor, BodyFunctor,
                                         1>::func(initial_values);
 };
 

--- a/include/cex_for_loop.h
+++ b/include/cex_for_loop.h
@@ -3,17 +3,17 @@
 
 #include "impl/cex_for_loop.h"
 
-namespace CEXForLoop {
+namespace cex_for_loop {
 
-template <long long start, long long end, long long inc,
+template <long long Start, long long End, long long Inc,
           typename BoolExpressionFunctor, typename BodyFunctor>
 constexpr typename BodyFunctor::Data constexpr_for(
     typename BodyFunctor::Data initial_values) {
   return impl::ExponentialCEXForFunctor<BoolExpressionFunctor, BodyFunctor,
-                                        start, end, inc,
+                                        Start, End, Inc,
                                         1>::func(initial_values);
 };
 
-}  // namespace CEXForLoop
+}  // namespace cex_for_loop
 
 #endif  // CEX_FOR_LOOP_H

--- a/include/impl/cex_for_loop.h
+++ b/include/impl/cex_for_loop.h
@@ -155,6 +155,6 @@ struct ExponentialCEXForFunctor {
 };
 
 }  // namespace impl
-}  // namespace CEXForLoop
+}  // namespace cex_for_loop
 
 #endif  // IMPL_CEX_FOR_LOOP_H

--- a/test/constexpr_for_test.cc
+++ b/test/constexpr_for_test.cc
@@ -7,11 +7,11 @@
 
 struct TestFunctorSetSmallIteration {
   struct Data {
-    std::array<int, 250> i_tracker;
+    std::array<uint32_t, 250> i_tracker;
     int last_i_value;
   };
 
-  template <long long I>
+  template <uint32_t I>
   static constexpr Data func(Data input_data) {
     std::get<I>(input_data.i_tracker) = I;
     input_data.last_i_value = I;
@@ -21,10 +21,10 @@ struct TestFunctorSetSmallIteration {
 
 struct TestFunctorAdd {
   struct Data {
-    long long kResult;
+    int64_t kResult;
   };
 
-  template <long long I>
+  template <int64_t I>
   static constexpr Data func(Data input_data) {
     input_data.kResult += I;
     return input_data;
@@ -32,11 +32,12 @@ struct TestFunctorAdd {
 };
 
 struct TestFunctorSetForNegative2IncNegative2Start {
+  using NumericType = int16_t;
   struct Data {
-    std::array<int, 200> i_tracker;
+    std::array<int16_t, 200> i_tracker;
   };
 
-  template <long long I>
+  template <int16_t I>
   static constexpr Data func(Data input_data) {
     std::get<(-1 * I / 2) - 1>(input_data.i_tracker) = I;
     return input_data;
@@ -45,11 +46,11 @@ struct TestFunctorSetForNegative2IncNegative2Start {
 
 struct TestFunctorSetLargeIterationIncBy3WithNegative1700Start {
   struct Data {
-    std::array<int, 1'000'000> i_tracker;
+    std::array<int64_t, 10'100> i_tracker;
     int last_i_value;
   };
 
-  template <long long I>
+  template <int64_t I>
   static constexpr Data func(Data input_data) {
     std::get<(I - 300) / -3>(input_data.i_tracker) = I;
     input_data.last_i_value = I;
@@ -59,11 +60,11 @@ struct TestFunctorSetLargeIterationIncBy3WithNegative1700Start {
 
 struct TestFunctorSetLargeIteration {
   struct Data {
-    std::array<int, 1'000'000> i_tracker;
-    int last_i_value;
+    std::array<uint64_t, 10'100> i_tracker;
+    uint64_t last_i_value;
   };
 
-  template <long long I>
+  template <uint64_t I>
   static constexpr Data func(Data input_data) {
     std::get<I>(input_data.i_tracker) = I;
     input_data.last_i_value = I;
@@ -72,12 +73,12 @@ struct TestFunctorSetLargeIteration {
 };
 
 TEST(ConstexprFor, ZeroToPositiveNumber) {
-  constexpr long long kTestTemplateDepth = 5;
+  constexpr uint32_t kTestTemplateDepth = 5;
   constexpr TestFunctorSetSmallIteration::Data kTestInitialValues = {
       {0, 0, 0, 0, 0}, 0};
 
   constexpr auto kResult =
-      cex_for_loop::constexpr_for<0, kTestTemplateDepth, 1,
+      cex_for_loop::constexpr_for<int32_t, 0, kTestTemplateDepth, 1,
                                   cex_for_loop::BoolExpressionFunctor_LT,
                                   TestFunctorSetSmallIteration>(
           kTestInitialValues);
@@ -97,12 +98,12 @@ TEST(ConstexprFor, ZeroToPositiveNumber) {
 }
 
 TEST(ConstexprFor, PositiveNumberToZero) {
-  constexpr long long kTestTemplateDepth = 5;
+  constexpr uint32_t kTestTemplateDepth = 5;
   constexpr TestFunctorSetSmallIteration::Data kTestInitialValues = {
       {0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, 0};
 
   constexpr auto kResult =
-      cex_for_loop::constexpr_for<kTestTemplateDepth, 0, -1,
+      cex_for_loop::constexpr_for<int32_t, kTestTemplateDepth - 1, 0, -1,
                                   cex_for_loop::BoolExpressionFunctor_GEQ,
                                   TestFunctorSetSmallIteration>(
           kTestInitialValues);
@@ -122,71 +123,83 @@ TEST(ConstexprFor, PositiveNumberToZero) {
 }
 
 TEST(ConstexprFor, ZeroToNegativeNumber) {
-  constexpr long long kTestTemplateDepth = 5;
+  constexpr int64_t kTestTemplateDepth = 5;
   constexpr TestFunctorAdd::Data kTestInitialValues = {};
 
   constexpr auto kResult =
-      cex_for_loop::constexpr_for<0, -kTestTemplateDepth, -1,
+      cex_for_loop::constexpr_for<int64_t, 0, -kTestTemplateDepth, -1,
                                   cex_for_loop::BoolExpressionFunctor_GT,
                                   TestFunctorAdd>(kTestInitialValues);
   ASSERT_EQ(0 - 1 - 2 - 3 - 4, kResult.kResult);
 }
 
 TEST(ConstexprFor, NegativeNumberToZero) {
-  constexpr long long kTestTemplateDepth = 5;
-  constexpr TestFunctorAdd::Data kTestInitialValues = {};
+  constexpr int64_t kTesttemplatedepth = 5;
+  constexpr TestFunctorAdd::Data kTestinitialvalues = {};
 
   constexpr auto kResult =
-      cex_for_loop::constexpr_for<-kTestTemplateDepth + 1, 0, 1,
+      cex_for_loop::constexpr_for<int64_t, -kTesttemplatedepth + 1, 0, 1,
                                   cex_for_loop::BoolExpressionFunctor_LEQ,
-                                  TestFunctorAdd>(kTestInitialValues);
+                                  TestFunctorAdd>(kTestinitialvalues);
   ASSERT_EQ(-4 - 3 - 2 - 1 - 0, kResult.kResult);
 }
 
 TEST(ConstexprFor, NegativeNumberToNegativeNumber) {
+  using UserProvidedType =
+      TestFunctorSetForNegative2IncNegative2Start::NumericType;
+  constexpr UserProvidedType kTestStart = -2;
+  constexpr UserProvidedType kTestEnd = -202;
+  constexpr UserProvidedType kTestInc = -2;
+
   constexpr TestFunctorSetForNegative2IncNegative2Start::Data
       kTestInitialValues = {};
 
   constexpr auto kResult =
-      cex_for_loop::constexpr_for<-2, -202, -2,
+      cex_for_loop::constexpr_for<UserProvidedType, kTestStart, kTestEnd,
+                                  kTestInc,
                                   cex_for_loop::BoolExpressionFunctor_GEQ,
                                   TestFunctorSetForNegative2IncNegative2Start>(
           kTestInitialValues);
 
+  std::array<UserProvidedType, 200> expected_i_tracker = {};
+  auto expected_i_inc = 0;
+  for (UserProvidedType i = kTestStart; i >= kTestEnd; i += kTestInc) {
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions)
+    expected_i_tracker[expected_i_inc] = i;
+    expected_i_inc++;
+  }
+
   // Uncomment to print i values in order
   // -----
   // std::string print_string;
-  // for (int i = 0; i < kResult.i_tracker.size(); i++) {
-  //   print_string.append(std::to_string(kResult.i_tracker[i]) + ", ");
+  // for (UserProvidedType value : kResult.i_tracker) {
+  //   print_string.append(std::to_string(value) + ", ");
   // }
-  // ADD_FAILURE() << print_string;
+  // ADD_FAILURE() << print_string
 
-  std::array<int, 101> expected_i_tracker = {};
-  for (int i = 0; i < 101; i++) {
-    expected_i_tracker[i] = -2 * i - 2;
-  }
-  for (std::size_t i = 0; i < 101; i++) {
-    ASSERT_EQ(kResult.i_tracker[i], expected_i_tracker[i]);
+  for (int i = 0; i < expected_i_inc; i++) {
+    ASSERT_EQ(kResult.i_tracker[i], expected_i_tracker[i]) << i;
   }
 }
 
 TEST(ConstexprFor, NegativeNumberToPositiveNumberBy3s) {
   constexpr TestFunctorAdd::Data kTestInitialValues = {};
 
-  constexpr auto kResult = cex_for_loop::constexpr_for<
-      -15, 15, 3, cex_for_loop::BoolExpressionFunctor_LEQ, TestFunctorAdd>(
-      kTestInitialValues);
+  constexpr auto kResult =
+      cex_for_loop::constexpr_for<int64_t, -15, 15, 3,
+                                  cex_for_loop::BoolExpressionFunctor_LEQ,
+                                  TestFunctorAdd>(kTestInitialValues);
 
   ASSERT_EQ(kResult.kResult, 0);
 }
 
 TEST(ConstexprFor, TemplateInstantiationDepth2000) {
-  constexpr long long kTestTemplateDepth = 2000;
+  constexpr int64_t kTestTemplateDepth = 2000;
   constexpr TestFunctorSetLargeIterationIncBy3WithNegative1700Start::Data
       kTestInitialValues = {};
 
   constexpr auto kResult = cex_for_loop::constexpr_for<
-      (-3 * kTestTemplateDepth) + 300, 300, 3,
+      int64_t, (-3 * kTestTemplateDepth) + 300, 300, 3,
       cex_for_loop::BoolExpressionFunctor_LEQ,
       TestFunctorSetLargeIterationIncBy3WithNegative1700Start>(
       kTestInitialValues);
@@ -203,11 +216,11 @@ TEST(ConstexprFor, TemplateInstantiationDepth2000) {
 }
 
 TEST(ConstexprFor, TemplateInstantiationDepth10000) {
-  constexpr long long kTestTemplateDepth = 10'000;
+  constexpr uint64_t kTestTemplateDepth = 10'000;
   constexpr TestFunctorSetLargeIteration::Data kTestInitialValues = {};
 
   constexpr auto kResult =
-      cex_for_loop::constexpr_for<1, kTestTemplateDepth, 1,
+      cex_for_loop::constexpr_for<int64_t, 1, kTestTemplateDepth, 1,
                                   cex_for_loop::BoolExpressionFunctor_LEQ,
                                   TestFunctorSetLargeIteration>(
           kTestInitialValues);

--- a/test/constexpr_for_test.cc
+++ b/test/constexpr_for_test.cc
@@ -5,223 +5,223 @@
 #include "include/bool_expression_functors.h"
 #include "include/cex_for_loop.h"
 
-struct TestFunctorSet_SmallIteration {
+struct TestFunctorSetSmallIteration {
   struct Data {
     std::array<int, 250> i_tracker;
     int last_i_value;
   };
 
-  template <long long i>
+  template <long long I>
   static constexpr Data func(Data input_data) {
-    std::get<i>(input_data.i_tracker) = i;
-    input_data.last_i_value = i;
+    std::get<I>(input_data.i_tracker) = I;
+    input_data.last_i_value = I;
     return input_data;
   };
 };
 
 struct TestFunctorAdd {
   struct Data {
-    long long result;
+    long long kResult;
   };
 
-  template <long long i>
+  template <long long I>
   static constexpr Data func(Data input_data) {
-    input_data.result += i;
+    input_data.kResult += I;
     return input_data;
   };
 };
 
-struct TestFunctorSet_ForNegative2IncNegative2Start {
+struct TestFunctorSetForNegative2IncNegative2Start {
   struct Data {
     std::array<int, 200> i_tracker;
   };
 
-  template <long long i>
+  template <long long I>
   static constexpr Data func(Data input_data) {
-    std::get<(-1 * i / 2) - 1>(input_data.i_tracker) = i;
+    std::get<(-1 * I / 2) - 1>(input_data.i_tracker) = I;
     return input_data;
   };
 };
 
-struct TestFunctorSet_LargeIterationIncBy3WithNegative1700Start {
+struct TestFunctorSetLargeIterationIncBy3WithNegative1700Start {
   struct Data {
     std::array<int, 1'000'000> i_tracker;
     int last_i_value;
   };
 
-  template <long long i>
+  template <long long I>
   static constexpr Data func(Data input_data) {
-    std::get<(i - 300) / -3>(input_data.i_tracker) = i;
-    input_data.last_i_value = i;
+    std::get<(I - 300) / -3>(input_data.i_tracker) = I;
+    input_data.last_i_value = I;
     return input_data;
   };
 };
 
-struct TestFunctorSet_LargeIteration {
+struct TestFunctorSetLargeIteration {
   struct Data {
     std::array<int, 1'000'000> i_tracker;
     int last_i_value;
   };
 
-  template <long long i>
+  template <long long I>
   static constexpr Data func(Data input_data) {
-    std::get<i>(input_data.i_tracker) = i;
-    input_data.last_i_value = i;
+    std::get<I>(input_data.i_tracker) = I;
+    input_data.last_i_value = I;
     return input_data;
   };
 };
 
 TEST(ConstexprFor, ZeroToPositiveNumber) {
-  constexpr long long test_template_depth = 5;
-  constexpr TestFunctorSet_SmallIteration::Data test_initial_values = {
+  constexpr long long kTestTemplateDepth = 5;
+  constexpr TestFunctorSetSmallIteration::Data kTestInitialValues = {
       {0, 0, 0, 0, 0}, 0};
 
-  constexpr auto result =
-      CEXForLoop::constexpr_for<0, test_template_depth, 1,
-                                CEXForLoop::BoolExpressionFunctor_LT,
-                                TestFunctorSet_SmallIteration>(
-          test_initial_values);
+  constexpr auto kResult =
+      cex_for_loop::constexpr_for<0, kTestTemplateDepth, 1,
+                                  cex_for_loop::BoolExpressionFunctor_LT,
+                                  TestFunctorSetSmallIteration>(
+          kTestInitialValues);
 
   // Uncomment to print i values in order
   // -----
   // std::string print_string;
-  // for (int i = 0; i < result.i_tracker.size(); i++) {
-  //   print_string.append(std::to_string(result.i_tracker[i]) + ", ");
+  // for (int i = 0; i < kResult.i_tracker.size(); i++) {
+  //   print_string.append(std::to_string(kResult.i_tracker[i]) + ", ");
   // }
   // ADD_FAILURE() << print_string;
 
-  ASSERT_EQ(result.last_i_value, test_template_depth - 1);
-  for (std::size_t i = 0; i < test_template_depth; i++) {
-    ASSERT_EQ(result.i_tracker[i], i);
+  ASSERT_EQ(kResult.last_i_value, kTestTemplateDepth - 1);
+  for (std::size_t i = 0; i < kTestTemplateDepth; i++) {
+    ASSERT_EQ(kResult.i_tracker[i], i);
   }
 }
 
 TEST(ConstexprFor, PositiveNumberToZero) {
-  constexpr long long test_template_depth = 5;
-  constexpr TestFunctorSet_SmallIteration::Data test_initial_values = {
+  constexpr long long kTestTemplateDepth = 5;
+  constexpr TestFunctorSetSmallIteration::Data kTestInitialValues = {
       {0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, 0};
 
-  constexpr auto result =
-      CEXForLoop::constexpr_for<test_template_depth, 0, -1,
-                                CEXForLoop::BoolExpressionFunctor_GEQ,
-                                TestFunctorSet_SmallIteration>(
-          test_initial_values);
+  constexpr auto kResult =
+      cex_for_loop::constexpr_for<kTestTemplateDepth, 0, -1,
+                                  cex_for_loop::BoolExpressionFunctor_GEQ,
+                                  TestFunctorSetSmallIteration>(
+          kTestInitialValues);
 
   // Uncomment to print i values in order
   // -----
   // std::string print_string;
-  // for (int i = 0; i < result.i_tracker.size(); i++) {
-  //   print_string.append(std::to_string(result.i_tracker[i]) + ", ");
+  // for (int i = 0; i < kResult.i_tracker.size(); i++) {
+  //   print_string.append(std::to_string(kResult.i_tracker[i]) + ", ");
   // }
   // ADD_FAILURE() << print_string;
 
-  for (std::size_t i = 0; i < test_template_depth; i++) {
-    ASSERT_EQ(result.i_tracker[i], i);
+  for (std::size_t i = 0; i < kTestTemplateDepth; i++) {
+    ASSERT_EQ(kResult.i_tracker[i], i);
   }
-  ASSERT_EQ(result.last_i_value, 0);
+  ASSERT_EQ(kResult.last_i_value, 0);
 }
 
 TEST(ConstexprFor, ZeroToNegativeNumber) {
-  constexpr long long test_template_depth = 5;
-  constexpr TestFunctorAdd::Data test_initial_values = {};
+  constexpr long long kTestTemplateDepth = 5;
+  constexpr TestFunctorAdd::Data kTestInitialValues = {};
 
-  constexpr auto result =
-      CEXForLoop::constexpr_for<0, -test_template_depth, -1,
-                                CEXForLoop::BoolExpressionFunctor_GT,
-                                TestFunctorAdd>(test_initial_values);
-  ASSERT_EQ(0 - 1 - 2 - 3 - 4, result.result);
+  constexpr auto kResult =
+      cex_for_loop::constexpr_for<0, -kTestTemplateDepth, -1,
+                                  cex_for_loop::BoolExpressionFunctor_GT,
+                                  TestFunctorAdd>(kTestInitialValues);
+  ASSERT_EQ(0 - 1 - 2 - 3 - 4, kResult.kResult);
 }
 
 TEST(ConstexprFor, NegativeNumberToZero) {
-  constexpr long long test_template_depth = 5;
-  constexpr TestFunctorAdd::Data test_initial_values = {};
+  constexpr long long kTestTemplateDepth = 5;
+  constexpr TestFunctorAdd::Data kTestInitialValues = {};
 
-  constexpr auto result =
-      CEXForLoop::constexpr_for<-test_template_depth + 1, 0, 1,
-                                CEXForLoop::BoolExpressionFunctor_LEQ,
-                                TestFunctorAdd>(test_initial_values);
-  ASSERT_EQ(-4 - 3 - 2 - 1 - 0, result.result);
+  constexpr auto kResult =
+      cex_for_loop::constexpr_for<-kTestTemplateDepth + 1, 0, 1,
+                                  cex_for_loop::BoolExpressionFunctor_LEQ,
+                                  TestFunctorAdd>(kTestInitialValues);
+  ASSERT_EQ(-4 - 3 - 2 - 1 - 0, kResult.kResult);
 }
 
 TEST(ConstexprFor, NegativeNumberToNegativeNumber) {
-  constexpr TestFunctorSet_ForNegative2IncNegative2Start::Data
-      test_initial_values = {};
+  constexpr TestFunctorSetForNegative2IncNegative2Start::Data
+      kTestInitialValues = {};
 
-  constexpr auto result =
-      CEXForLoop::constexpr_for<-2, -202, -2,
-                                CEXForLoop::BoolExpressionFunctor_GEQ,
-                                TestFunctorSet_ForNegative2IncNegative2Start>(
-          test_initial_values);
+  constexpr auto kResult =
+      cex_for_loop::constexpr_for<-2, -202, -2,
+                                  cex_for_loop::BoolExpressionFunctor_GEQ,
+                                  TestFunctorSetForNegative2IncNegative2Start>(
+          kTestInitialValues);
 
   // Uncomment to print i values in order
   // -----
   // std::string print_string;
-  // for (int i = 0; i < result.i_tracker.size(); i++) {
-  //   print_string.append(std::to_string(result.i_tracker[i]) + ", ");
+  // for (int i = 0; i < kResult.i_tracker.size(); i++) {
+  //   print_string.append(std::to_string(kResult.i_tracker[i]) + ", ");
   // }
   // ADD_FAILURE() << print_string;
 
   std::array<int, 101> expected_i_tracker = {};
-  for (std::size_t i = 0; i < 101; i++) {
+  for (int i = 0; i < 101; i++) {
     expected_i_tracker[i] = -2 * i - 2;
   }
   for (std::size_t i = 0; i < 101; i++) {
-    ASSERT_EQ(result.i_tracker[i], expected_i_tracker[i]);
+    ASSERT_EQ(kResult.i_tracker[i], expected_i_tracker[i]);
   }
 }
 
 TEST(ConstexprFor, NegativeNumberToPositiveNumberBy3s) {
-  constexpr TestFunctorAdd::Data test_initial_values = {};
+  constexpr TestFunctorAdd::Data kTestInitialValues = {};
 
-  constexpr auto result = CEXForLoop::constexpr_for<
-      -15, 15, 3, CEXForLoop::BoolExpressionFunctor_LEQ, TestFunctorAdd>(
-      test_initial_values);
+  constexpr auto kResult = cex_for_loop::constexpr_for<
+      -15, 15, 3, cex_for_loop::BoolExpressionFunctor_LEQ, TestFunctorAdd>(
+      kTestInitialValues);
 
-  ASSERT_EQ(result.result, 0);
+  ASSERT_EQ(kResult.kResult, 0);
 }
 
 TEST(ConstexprFor, TemplateInstantiationDepth2000) {
-  constexpr long long test_template_depth = 2000;
-  constexpr TestFunctorSet_LargeIterationIncBy3WithNegative1700Start::Data
-      test_initial_values = {};
+  constexpr long long kTestTemplateDepth = 2000;
+  constexpr TestFunctorSetLargeIterationIncBy3WithNegative1700Start::Data
+      kTestInitialValues = {};
 
-  constexpr auto result = CEXForLoop::constexpr_for<
-      (-3 * test_template_depth) + 300, 300, 3,
-      CEXForLoop::BoolExpressionFunctor_LEQ,
-      TestFunctorSet_LargeIterationIncBy3WithNegative1700Start>(
-      test_initial_values);
+  constexpr auto kResult = cex_for_loop::constexpr_for<
+      (-3 * kTestTemplateDepth) + 300, 300, 3,
+      cex_for_loop::BoolExpressionFunctor_LEQ,
+      TestFunctorSetLargeIterationIncBy3WithNegative1700Start>(
+      kTestInitialValues);
 
   // Uncomment to print i values in order
   // -----
   // std::string print_string;
-  // for (int i = 0; i < test_template_depth; i++) {
-  //   print_string.append(std::to_string(result.i_tracker[i]) + ", ");
+  // for (int i = 0; i < kTestTemplateDepth; i++) {
+  //   print_string.append(std::to_string(kResult.i_tracker[i]) + ", ");
   // }
   // ADD_FAILURE() << print_string;
 
-  ASSERT_EQ(result.last_i_value, 300);
+  ASSERT_EQ(kResult.last_i_value, 300);
 }
 
 TEST(ConstexprFor, TemplateInstantiationDepth10000) {
-  constexpr long long test_template_depth = 10'000;
-  constexpr TestFunctorSet_LargeIteration::Data test_initial_values = {};
+  constexpr long long kTestTemplateDepth = 10'000;
+  constexpr TestFunctorSetLargeIteration::Data kTestInitialValues = {};
 
-  constexpr auto result =
-      CEXForLoop::constexpr_for<1, test_template_depth, 1,
-                                CEXForLoop::BoolExpressionFunctor_LEQ,
-                                TestFunctorSet_LargeIteration>(
-          test_initial_values);
+  constexpr auto kResult =
+      cex_for_loop::constexpr_for<1, kTestTemplateDepth, 1,
+                                  cex_for_loop::BoolExpressionFunctor_LEQ,
+                                  TestFunctorSetLargeIteration>(
+          kTestInitialValues);
 
   // Uncomment to print i values in order
   // -----
   // std::string print_string;
-  // for (int i = 0; i < test_template_depth; i++) {
-  //   print_string.append(std::to_string(result.i_tracker[i]) + ", ");
+  // for (int i = 0; i < kTestTemplateDepth; i++) {
+  //   print_string.append(std::to_string(kResult.i_tracker[i]) + ", ");
   // }
   // ADD_FAILURE() << print_string;
 
-  ASSERT_EQ(result.last_i_value, test_template_depth);
-  for (std::size_t i = 0; i < test_template_depth; i++) {
-    ASSERT_EQ(result.i_tracker[i], i);
+  ASSERT_EQ(kResult.last_i_value, kTestTemplateDepth);
+  for (std::size_t i = 0; i < kTestTemplateDepth; i++) {
+    ASSERT_EQ(kResult.i_tracker[i], i);
   }
 }


### PR DESCRIPTION
- **refactor: add and apply non-structural clang-tidy checks**
- **fix: fix closing namespace comment**
- **!feat: add user-provided type to constexpr for loop structs**
