### PR TITLE
refactor(bool_expression_functors): make them templated on user provided type

### DIFF
--- a/include/bool_expression_functors.h
+++ b/include/bool_expression_functors.h
@@ -5,44 +5,80 @@ namespace cex_for_loop {
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_EQ {
-  inline static constexpr bool func(long long lhs, long long rhs) {
-    return lhs == rhs;
-  }
+  // The templated struct within allows user to pass this type without having
+  // to pass the template parameter at the call-site meaning the CEXForLoop can
+  // be "DRY" (Don't Repeat Yourself)
+  template <typename IType>
+  struct WithType {
+    inline static constexpr bool func(IType lhs, IType rhs) {
+      return lhs == rhs;
+    }
+  };
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_NEQ {
-  inline static constexpr bool func(long long lhs, long long rhs) {
-    return lhs != rhs;
-  }
+  // The templated struct within allows user to pass this type without having
+  // to pass the template parameter at the call-site meaning the CEXForLoop can
+  // be "DRY" (Don't Repeat Yourself)
+  template <typename IType>
+  struct WithType {
+    inline static constexpr bool func(IType lhs, IType rhs) {
+      return lhs != rhs;
+    }
+  };
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_LT {
-  inline static constexpr bool func(long long lhs, long long rhs) {
-    return lhs < rhs;
-  }
+  // The templated struct within allows user to pass this type without having
+  // to pass the template parameter at the call-site meaning the CEXForLoop can
+  // be "DRY" (Don't Repeat Yourself)
+  template <typename IType>
+  struct WithType {
+    inline static constexpr bool func(IType lhs, IType rhs) {
+      return lhs < rhs;
+    }
+  };
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_LEQ {
-  inline static constexpr bool func(long long lhs, long long rhs) {
-    return lhs <= rhs;
-  }
+  // The templated struct within allows user to pass this type without having
+  // to pass the template parameter at the call-site meaning the CEXForLoop can
+  // be "DRY" (Don't Repeat Yourself)
+  template <typename IType>
+  struct WithType {
+    inline static constexpr bool func(IType lhs, IType rhs) {
+      return lhs <= rhs;
+    }
+  };
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_GT {
-  inline static constexpr bool func(long long lhs, long long rhs) {
-    return lhs > rhs;
-  }
+  // The templated struct within allows user to pass this type without having
+  // to pass the template parameter at the call-site meaning the CEXForLoop can
+  // be "DRY" (Don't Repeat Yourself)
+  template <typename IType>
+  struct WithType {
+    inline static constexpr bool func(IType lhs, IType rhs) {
+      return lhs > rhs;
+    }
+  };
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 struct BoolExpressionFunctor_GEQ {
-  inline static constexpr bool func(long long lhs, long long rhs) {
-    return lhs >= rhs;
-  }
+  // The templated struct within allows user to pass this type without having
+  // to pass the template parameter at the call-site meaning the CEXForLoop can
+  // be "DRY" (Don't Repeat Yourself)
+  template <typename IType>
+  struct WithType {
+    inline static constexpr bool func(IType lhs, IType rhs) {
+      return lhs >= rhs;
+    }
+  };
 };
 
 }  // namespace cex_for_loop


### PR DESCRIPTION
- Chose to make the internals kinda gross so that users of the library
  can have a cleaner call-site without repeating information.
  - Have a templated struct within the bool expression functors so that
    the bool expression functor can still be passed without a template
    parameter. Then within the library internals, the bool expression
    function is accessed and templated using user provided type.
